### PR TITLE
Fix issues with 'slim' images breaking builds

### DIFF
--- a/3.10-slim/Dockerfile
+++ b/3.10-slim/Dockerfile
@@ -7,6 +7,9 @@
 FROM python:3.10-slim
 MAINTAINER Stephen Neal <stephen@stephenneal.net>
 
+# Copy Python dependencies list
+COPY ./requirements.txt ./requirements.txt
+
 # Update OS & install dependencies
 RUN set -ex \
     && buildDeps=' \
@@ -32,7 +35,7 @@ RUN set -ex \
     ' \
     && apt-get update \
     && apt-get install -y $buildDeps $deps --no-install-recommends \
-    && pip install uwsgi \
+    && pip install $(grep -C 0 "uWSGI" requirements.txt ) \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove $buildDeps \
     && find /usr/local -depth \
@@ -43,7 +46,6 @@ RUN set -ex \
     \) -exec rm -rf '{}' +
 
 # Install Python dependencies
-COPY ./requirements.txt ./requirements.txt
 RUN pip3 install --upgrade pip \
 	&& pip3 install -r ./requirements.txt \
 	&& rm ./requirements.txt

--- a/3.11-slim/Dockerfile
+++ b/3.11-slim/Dockerfile
@@ -7,6 +7,9 @@
 FROM python:3.11-slim
 MAINTAINER Stephen Neal <stephen@stephenneal.net>
 
+# Copy Python dependencies list
+COPY ./requirements.txt ./requirements.txt
+
 # Update OS & install dependencies
 RUN set -ex \
     && buildDeps=' \
@@ -32,7 +35,7 @@ RUN set -ex \
     ' \
     && apt-get update \
     && apt-get install -y $buildDeps $deps --no-install-recommends \
-    && pip install uwsgi \
+    && pip install $(grep -C 0 "uWSGI" requirements.txt ) \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove $buildDeps \
     && find /usr/local -depth \
@@ -42,8 +45,7 @@ RUN set -ex \
         \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
     \) -exec rm -rf '{}' +
 
-# Update pip & install flask & uwsgi dependencies
-COPY ./requirements.txt ./requirements.txt
+# Install Python dependencies
 RUN pip3 install --upgrade pip \
 	&& pip3 install -r ./requirements.txt \
 	&& rm ./requirements.txt

--- a/3.12-slim/Dockerfile
+++ b/3.12-slim/Dockerfile
@@ -7,6 +7,9 @@
 FROM python:3.12-slim
 MAINTAINER Stephen Neal <stephen@stephenneal.net>
 
+# Copy Python dependencies list
+COPY ./requirements.txt ./requirements.txt
+
 # Update OS & install dependencies
 RUN set -ex \
     && buildDeps=' \
@@ -32,7 +35,7 @@ RUN set -ex \
     ' \
     && apt-get update \
     && apt-get install -y $buildDeps $deps --no-install-recommends \
-    && pip install uwsgi \
+    && pip install $(grep -C 0 "uWSGI" requirements.txt ) \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove $buildDeps \
     && find /usr/local -depth \
@@ -43,7 +46,6 @@ RUN set -ex \
     \) -exec rm -rf '{}' +
 
 # Install Python dependencies
-COPY ./requirements.txt ./requirements.txt
 RUN pip3 install --upgrade pip \
 	&& pip3 install -r ./requirements.txt \
 	&& rm ./requirements.txt

--- a/3.8-slim/Dockerfile
+++ b/3.8-slim/Dockerfile
@@ -7,6 +7,9 @@
 FROM python:3.8-slim
 MAINTAINER Stephen Neal <stephen@stephenneal.net>
 
+# Copy Python dependencies list
+COPY ./requirements.txt ./requirements.txt
+
 # Update OS & install dependencies
 RUN set -ex \
     && buildDeps=' \
@@ -32,7 +35,7 @@ RUN set -ex \
     ' \
     && apt-get update \
     && apt-get install -y $buildDeps $deps --no-install-recommends \
-    && pip install uwsgi \
+    && pip install $(grep -C 0 "uWSGI" requirements.txt ) \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove $buildDeps \
     && find /usr/local -depth \
@@ -43,7 +46,6 @@ RUN set -ex \
     \) -exec rm -rf '{}' +
 
 # Install Python dependencies
-COPY ./requirements.txt ./requirements.txt
 RUN pip3 install --upgrade pip \
 	&& pip3 install -r ./requirements.txt \
 	&& rm ./requirements.txt

--- a/3.9-slim/Dockerfile
+++ b/3.9-slim/Dockerfile
@@ -7,6 +7,9 @@
 FROM python:3.9-slim
 MAINTAINER Stephen Neal <stephen@stephenneal.net>
 
+# Copy Python dependencies list
+COPY ./requirements.txt ./requirements.txt
+
 # Update OS & install dependencies
 RUN set -ex \
     && buildDeps=' \
@@ -32,7 +35,7 @@ RUN set -ex \
     ' \
     && apt-get update \
     && apt-get install -y $buildDeps $deps --no-install-recommends \
-    && pip install uwsgi \
+    && pip install $(grep -C 0 "uWSGI" requirements.txt ) \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge -y --auto-remove $buildDeps \
     && find /usr/local -depth \
@@ -43,7 +46,6 @@ RUN set -ex \
     \) -exec rm -rf '{}' +
 
 # Install Python dependencies
-COPY ./requirements.txt ./requirements.txt
 RUN pip3 install --upgrade pip \
 	&& pip3 install -r ./requirements.txt \
 	&& rm ./requirements.txt


### PR DESCRIPTION
- fix issues with 'slim' images
- add installing the specified version of the uWSGI package during the system update step to avoid trying to reinstall it again in the pip step